### PR TITLE
Add reusable group assignment algorithms and tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
-      - name: Run tests
-        run: pnpm test -- --runInBand
+      - name: Run unit tests
+        run: pnpm test:unit -- --run
+
+      - name: Run Playwright tests
+        run: pnpm test:e2e

--- a/src/lib/algorithms/balanced-assignment.spec.ts
+++ b/src/lib/algorithms/balanced-assignment.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { assignBalanced } from './balanced-assignment';
+import type { AssignmentOptions } from './types';
+import type { Group, Student } from '$lib/types';
+import type { StudentPreference } from '$lib/types/preferences';
+
+function buildOptions(
+        groups: Group[],
+        students: Student[],
+        preferences: StudentPreference[],
+        order: string[],
+        overrides: Partial<AssignmentOptions> = {}
+): AssignmentOptions {
+        const studentsById = Object.fromEntries(students.map((s) => [s.id, s]));
+        const preferencesById = Object.fromEntries(preferences.map((p) => [p.studentId, p]));
+        return {
+                groups,
+                studentOrder: order,
+                studentsById,
+                preferencesById,
+                ...overrides
+        };
+}
+
+describe('assignBalanced', () => {
+        it('clusters mutual friends into the same group when capacity allows', () => {
+                const groups: Group[] = [
+                        { id: 'g1', name: 'Group 1', capacity: 2, memberIds: [] },
+                        { id: 'g2', name: 'Group 2', capacity: 2, memberIds: [] }
+                ];
+                const students: Student[] = [
+                        { id: 'a' },
+                        { id: 'b' },
+                        { id: 'c' },
+                        { id: 'd' }
+                ];
+                const preferences: StudentPreference[] = [
+                        { studentId: 'a', likeStudentIds: ['b'], avoidStudentIds: [], likeGroupIds: [], avoidGroupIds: [] },
+                        { studentId: 'b', likeStudentIds: ['a'], avoidStudentIds: [], likeGroupIds: [], avoidGroupIds: [] },
+                        { studentId: 'c', likeStudentIds: ['d'], avoidStudentIds: [], likeGroupIds: [], avoidGroupIds: [] },
+                        { studentId: 'd', likeStudentIds: ['c'], avoidStudentIds: [], likeGroupIds: [], avoidGroupIds: [] }
+                ];
+
+                const result = assignBalanced(
+                        buildOptions(groups, students, preferences, students.map((s) => s.id))
+                );
+
+                const hasAB = result.groups.some((group) =>
+                        group.memberIds.includes('a') && group.memberIds.includes('b')
+                );
+                const hasCD = result.groups.some((group) =>
+                        group.memberIds.includes('c') && group.memberIds.includes('d')
+                );
+
+                expect(hasAB).toBe(true);
+                expect(hasCD).toBe(true);
+                expect(result.unassignedStudentIds).toHaveLength(0);
+        });
+
+        it('honors capacity limits and reports unassigned students', () => {
+                const groups: Group[] = [{ id: 'g1', name: 'Only Group', capacity: 2, memberIds: [] }];
+                const students: Student[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+                const preferences: StudentPreference[] = students.map((student) => ({
+                        studentId: student.id,
+                        likeStudentIds: [],
+                        avoidStudentIds: [],
+                        likeGroupIds: [],
+                        avoidGroupIds: []
+                }));
+
+                const result = assignBalanced(
+                        buildOptions(groups, students, preferences, students.map((s) => s.id))
+                );
+
+                const totalAssigned = result.groups.reduce(
+                        (sum, group) => sum + group.memberIds.length,
+                        0
+                );
+
+                expect(totalAssigned).toBe(2);
+                expect(result.unassignedStudentIds).toHaveLength(1);
+                expect(result.unassignedStudentIds[0]).toBeDefined();
+        });
+});

--- a/src/lib/algorithms/balanced-assignment.ts
+++ b/src/lib/algorithms/balanced-assignment.ts
@@ -1,0 +1,139 @@
+import type { Group } from '$lib/types';
+import { neighborsHappinessImpact, studentHappinessForMembers } from './happiness';
+import type { AssignmentOptions, AssignmentResult, HappinessContext } from './types';
+
+export function assignBalanced(options: AssignmentOptions): AssignmentResult {
+        const emptyGroups = options.groups.map((group) => ({
+                ...group,
+                memberIds: [] as string[]
+        }));
+
+        const adjacency = buildMutualFriendAdjacency(options);
+        const degree = (id: string) => adjacency.get(id)?.size ?? 0;
+        const order = [...options.studentOrder].sort((a, b) => degree(b) - degree(a));
+
+        const memberMap: Record<string, string[]> = {};
+        for (const group of emptyGroups) memberMap[group.id] = [];
+
+        const unassigned: string[] = [];
+
+        for (const studentId of order) {
+                let bestGroup: Group | null = null;
+                let bestScore = -1;
+
+                for (const group of emptyGroups) {
+                        const remaining = remainingCapacity(group, memberMap[group.id]);
+                        if (remaining <= 0) continue;
+
+                        const members = memberMap[group.id];
+                        const set = new Set(members);
+                        let score = 0;
+                        for (const friendId of adjacency.get(studentId) ?? []) {
+                                if (set.has(friendId)) score++;
+                        }
+
+                        if (score > bestScore) {
+                                bestScore = score;
+                                bestGroup = group;
+                        }
+                }
+
+                if (bestGroup) {
+                        memberMap[bestGroup.id].push(studentId);
+                } else {
+                        unassigned.push(studentId);
+                }
+        }
+
+        let workingGroups = emptyGroups.map((group) => ({
+                ...group,
+                memberIds: memberMap[group.id]
+        }));
+
+        const context: HappinessContext = {
+                preferencesById: options.preferencesById,
+                studentsById: options.studentsById
+        };
+        const swapBudget = options.swapBudget ?? 300;
+
+        for (let i = 0; i < swapBudget; i++) {
+                const a = pickRandomPlaced(workingGroups);
+                const b = pickRandomPlaced(workingGroups);
+                if (!a || !b || a.id === b.id || a.group.id === b.group.id) continue;
+
+                const delta = swapDeltaHappiness(a.id, b.id, a.group, b.group, context);
+                if (delta > 0) {
+                        const ai = a.group.memberIds.indexOf(a.id);
+                        const bi = b.group.memberIds.indexOf(b.id);
+                        a.group.memberIds[ai] = b.id;
+                        b.group.memberIds[bi] = a.id;
+                }
+        }
+
+        return { groups: workingGroups, unassignedStudentIds: unassigned };
+}
+
+function remainingCapacity(group: Group, memberIds: string[]): number {
+        if (group.capacity == null) return Infinity;
+        return group.capacity - memberIds.length;
+}
+
+function pickRandomPlaced(groups: Group[]): { id: string; group: Group } | null {
+        const placed: { id: string; group: Group }[] = [];
+        for (const group of groups) {
+                for (const id of group.memberIds) {
+                        placed.push({ id, group });
+                }
+        }
+        if (!placed.length) return null;
+        return placed[(Math.random() * placed.length) | 0];
+}
+
+function swapDeltaHappiness(
+        aId: string,
+        bId: string,
+        groupA: Group,
+        groupB: Group,
+        context: HappinessContext
+): number {
+        const before =
+                studentHappinessForMembers(aId, groupA.memberIds, context) +
+                studentHappinessForMembers(bId, groupB.memberIds, context) +
+                neighborsHappinessImpact(groupA.memberIds, aId, context) +
+                neighborsHappinessImpact(groupB.memberIds, bId, context);
+
+        const ai = groupA.memberIds.indexOf(aId);
+        const bi = groupB.memberIds.indexOf(bId);
+        groupA.memberIds[ai] = bId;
+        groupB.memberIds[bi] = aId;
+
+        const after =
+                studentHappinessForMembers(aId, groupB.memberIds, context) +
+                studentHappinessForMembers(bId, groupA.memberIds, context) +
+                neighborsHappinessImpact(groupA.memberIds, bId, context) +
+                neighborsHappinessImpact(groupB.memberIds, aId, context);
+
+        groupA.memberIds[ai] = aId;
+        groupB.memberIds[bi] = bId;
+
+        return after - before;
+}
+
+function buildMutualFriendAdjacency(options: AssignmentOptions): Map<string, Set<string>> {
+        const adjacency = new Map<string, Set<string>>();
+        for (const id of options.studentOrder) adjacency.set(id, new Set());
+
+        const { preferencesById, studentsById } = options;
+        for (const [studentId, pref] of Object.entries(preferencesById)) {
+                for (const friendId of pref.likeStudentIds ?? []) {
+                        if (!studentsById[friendId] || !studentsById[studentId]) continue;
+                        const friendPref = preferencesById[friendId];
+                        if (friendPref?.likeStudentIds?.includes(studentId)) {
+                                adjacency.get(studentId)?.add(friendId);
+                                adjacency.get(friendId)?.add(studentId);
+                        }
+                }
+        }
+
+        return adjacency;
+}

--- a/src/lib/algorithms/happiness.spec.ts
+++ b/src/lib/algorithms/happiness.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { Group, Student } from '$lib/types';
+import type { StudentPreference } from '$lib/types/preferences';
+import { neighborsHappinessImpact, studentHappinessForMembers, studentHappinessInGroups } from './happiness';
+import type { HappinessContext } from './types';
+
+const students: Record<string, Student> = {
+        a: { id: 'a' },
+        b: { id: 'b' },
+        c: { id: 'c' }
+};
+
+const preferences: Record<string, StudentPreference> = {
+        a: { studentId: 'a', likeStudentIds: ['b', 'c'], avoidStudentIds: [], likeGroupIds: [], avoidGroupIds: [] },
+        b: { studentId: 'b', likeStudentIds: ['a'], avoidStudentIds: [], likeGroupIds: [], avoidGroupIds: [] },
+        c: { studentId: 'c', likeStudentIds: [], avoidStudentIds: [], likeGroupIds: [], avoidGroupIds: [] }
+};
+
+const context: HappinessContext = {
+        preferencesById: preferences,
+        studentsById: students
+};
+
+describe('happiness utilities', () => {
+        it('counts how many liked friends are present in the group', () => {
+                const happiness = studentHappinessForMembers('a', ['a', 'b'], context);
+                expect(happiness).toBe(1);
+        });
+
+        it('returns zero when student is not assigned to any group', () => {
+                const groups: Group[] = [
+                        { id: 'g1', name: 'G1', capacity: 3, memberIds: ['b', 'c'] },
+                        { id: 'g2', name: 'G2', capacity: 3, memberIds: [] }
+                ];
+                expect(studentHappinessInGroups('a', groups, context)).toBe(0);
+        });
+
+        it('measures neighbor impact for a moved student', () => {
+                const members = ['a', 'b', 'c'];
+                const impact = neighborsHappinessImpact(members, 'a', context);
+                expect(impact).toBeGreaterThan(0);
+        });
+});

--- a/src/lib/algorithms/happiness.ts
+++ b/src/lib/algorithms/happiness.ts
@@ -1,0 +1,44 @@
+import type { Group } from '$lib/types';
+import type { HappinessContext } from './types';
+
+export function studentHappinessInGroups(
+        studentId: string,
+        groups: Group[],
+        context: HappinessContext
+): number {
+        const group = groups.find((g) => g.memberIds.includes(studentId));
+        if (!group) return 0;
+        return studentHappinessForMembers(studentId, group.memberIds, context);
+}
+
+export function studentHappinessForMembers(
+        studentId: string,
+        memberIds: readonly string[],
+        context: HappinessContext
+): number {
+        const pref = context.preferencesById[studentId];
+        if (!pref?.likeStudentIds?.length) return 0;
+
+        const memberSet = new Set(memberIds);
+        let count = 0;
+        for (const friendId of pref.likeStudentIds) {
+                if (!context.studentsById[friendId]) continue;
+                if (memberSet.has(friendId)) count++;
+        }
+        return count;
+}
+
+export function neighborsHappinessImpact(
+        memberIds: readonly string[],
+        movedStudentId: string,
+        context: HappinessContext
+): number {
+        let sum = 0;
+        for (const otherId of memberIds) {
+                        if (otherId === movedStudentId) continue;
+                        const pref = context.preferencesById[otherId];
+                        if (!pref?.likeStudentIds?.includes(movedStudentId)) continue;
+                        sum += studentHappinessForMembers(otherId, memberIds, context);
+        }
+        return sum;
+}

--- a/src/lib/algorithms/types.ts
+++ b/src/lib/algorithms/types.ts
@@ -1,0 +1,20 @@
+import type { Group, Student } from '$lib/types';
+import type { StudentPreference } from '$lib/types/preferences';
+
+export interface AssignmentOptions {
+        groups: Group[];
+        studentOrder: string[];
+        preferencesById: Record<string, StudentPreference>;
+        studentsById: Record<string, Student>;
+        swapBudget?: number;
+}
+
+export interface AssignmentResult {
+        groups: Group[];
+        unassignedStudentIds: string[];
+}
+
+export interface HappinessContext {
+        preferencesById: Record<string, StudentPreference>;
+        studentsById: Record<string, Student>;
+}

--- a/src/lib/services/groupAssignment.ts
+++ b/src/lib/services/groupAssignment.ts
@@ -1,3 +1,5 @@
+import { assignBalanced } from '$lib/algorithms/balanced-assignment';
+import { studentHappinessInGroups } from '$lib/algorithms/happiness';
 import type { CommandStore } from '$lib/stores/commands.svelte';
 import type { Group, Student } from '$lib/types';
 import type { StudentPreference } from '$lib/types/preferences';
@@ -19,24 +21,11 @@ export function createGroupAssignmentService({
         getStudentsById,
         resetCollapsedGroups
 }: AssignmentDependencies) {
-        function groupOf(studentId: string): Group | null {
-                const groups = getGroups();
-                for (const g of groups) if (g.memberIds.includes(studentId)) return g;
-                return null;
-        }
-
         function studentHappiness(studentId: string): number {
-                const pref = getPreferencesById()[studentId];
-                if (!pref || !pref.likeStudentIds?.length) return 0;
-                const g = groupOf(studentId);
-                if (!g) return 0;
-                const set = new Set(g.memberIds);
-                const studentsById = getStudentsById();
-                let count = 0;
-                for (const fid of pref.likeStudentIds) {
-                        if (studentsById[fid] && set.has(fid)) count++;
-                }
-                return count;
+                return studentHappinessInGroups(studentId, getGroups(), {
+                        preferencesById: getPreferencesById(),
+                        studentsById: getStudentsById()
+                });
         }
 
         function clearAndRandomAssign() {
@@ -65,135 +54,16 @@ export function createGroupAssignmentService({
                 resetCollapsedGroups();
         }
 
-        function buildAdjacency(): Map<string, Set<string>> {
-                const adj = new Map<string, Set<string>>();
-                for (const id of getStudentOrder()) adj.set(id, new Set());
-                const preferences = getPreferencesById();
-                const students = getStudentsById();
-                for (const [sid, pref] of Object.entries(preferences)) {
-                        for (const fid of pref.likeStudentIds) {
-                                if (!students[fid] || !students[sid]) continue;
-                                const otherPref = preferences[fid];
-                                if (otherPref && otherPref.likeStudentIds.includes(sid)) {
-                                        adj.get(sid)!.add(fid);
-                                        adj.get(fid)!.add(sid);
-                                }
-                        }
-                }
-                return adj;
-        }
-
         function autoAssignBalanced() {
-                const currentGroups = commandStore.groups;
-                const emptyGroups = currentGroups.map((g) => ({ ...g, memberIds: [] }));
-                const adj = buildAdjacency();
-                const degree = (id: string) => adj.get(id)?.size ?? 0;
-                const order = [...getStudentOrder()].sort((a, b) => degree(b) - degree(a));
-
-                const newMemberIds: Record<string, string[]> = {};
-                emptyGroups.forEach((g) => {
-                        newMemberIds[g.id] = [];
+                const result = assignBalanced({
+                        groups: commandStore.groups,
+                        studentOrder: getStudentOrder(),
+                        preferencesById: getPreferencesById(),
+                        studentsById: getStudentsById()
                 });
 
-                const remaining = (gid: string) => {
-                        const g = emptyGroups.find((gr) => gr.id === gid);
-                        if (!g) return 0;
-                        return g.capacity == null ? Infinity : g.capacity - newMemberIds[gid].length;
-                };
-
-                for (const id of order) {
-                        let bestG: string | null = null;
-                        let bestScore = -1;
-
-                        for (const g of emptyGroups) {
-                                if (remaining(g.id) <= 0) continue;
-
-                                let sc = 0;
-                                const set = new Set(newMemberIds[g.id]);
-                                for (const fid of adj.get(id) ?? []) {
-                                        if (set.has(fid)) sc++;
-                                }
-
-                                if (sc > bestScore) {
-                                        bestScore = sc;
-                                        bestG = g.id;
-                                }
-                        }
-
-                        if (bestG) {
-                                newMemberIds[bestG].push(id);
-                        }
-                }
-
-                let workingGroups = emptyGroups.map((g) => ({
-                        ...g,
-                        memberIds: newMemberIds[g.id]
-                }));
-
-                const budget = 300;
-                for (let t = 0; t < budget; t++) {
-                        const a = pickRandomPlaced();
-                        const b = pickRandomPlaced();
-                        if (!a || !b || a.id === b.id || a.group.id === b.group.id) continue;
-
-                        const delta = swapDeltaHappiness(a.id, b.id, a.group, b.group);
-                        if (delta > 0) {
-                                const ai = a.group.memberIds.indexOf(a.id);
-                                const bi = b.group.memberIds.indexOf(b.id);
-                                a.group.memberIds[ai] = b.id;
-                                b.group.memberIds[bi] = a.id;
-                        }
-                }
-
-                commandStore.initializeGroups(workingGroups);
+                commandStore.initializeGroups(result.groups);
                 resetCollapsedGroups();
-
-                function pickRandomPlaced() {
-                        const placedPairs: { id: string; group: Group }[] = [];
-                        for (const g of workingGroups) {
-                                for (const id of g.memberIds) {
-                                        placedPairs.push({ id, group: g });
-                                }
-                        }
-                        if (!placedPairs.length) return null;
-                        return placedPairs[(Math.random() * placedPairs.length) | 0];
-                }
-
-                function swapDeltaHappiness(aId: string, bId: string, gA: Group, gB: Group) {
-                        const before =
-                                studentHappiness(aId) +
-                                studentHappiness(bId) +
-                                neighborsDeltaContext(gA, aId) +
-                                neighborsDeltaContext(gB, bId);
-
-                        const ai = gA.memberIds.indexOf(aId);
-                        const bi = gB.memberIds.indexOf(bId);
-                        gA.memberIds[ai] = bId;
-                        gB.memberIds[bi] = aId;
-
-                        const after =
-                                studentHappiness(aId) +
-                                studentHappiness(bId) +
-                                neighborsDeltaContext(gA, bId) +
-                                neighborsDeltaContext(gB, aId);
-
-                        gA.memberIds[ai] = aId;
-                        gB.memberIds[bi] = bId;
-
-                        return after - before;
-                }
-
-                function neighborsDeltaContext(g: Group, movedId: string) {
-                        let sum = 0;
-                        const preferences = getPreferencesById();
-                        for (const otherId of g.memberIds) {
-                                const otherPref = preferences[otherId];
-                                if (otherPref?.likeStudentIds?.includes(movedId)) {
-                                        sum += studentHappiness(otherId);
-                                }
-                        }
-                        return sum;
-                }
         }
 
         return {


### PR DESCRIPTION
## Summary
- extract the balanced assignment logic into reusable modules under `src/lib/algorithms` and expose a typed `assignBalanced` helper together with happiness utilities
- update the group assignment service to consume the shared helpers so the UI keeps a single source of truth for the algorithm
- cover the algorithms with Vitest suites and ensure CI runs the unit and Playwright suites independently

## Testing
- `pnpm exec vitest run --project server`
- `pnpm test:unit -- --run` *(fails: missing Playwright browsers in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b877d5c6483288dd376f5e1e411e4)