### PR TITLE
Refactor ui settings store

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,50 @@ For strategic choices (scope, architecture, product, process):
 - Derived state via `$derived` or `$derived.by()`
 - State via `$state`
 
+### Stores ($state runes)
+- Keep each store inside a `.svelte.ts` file and model it as a class with `$state` fields.
+- Provide intent-revealing helpers (`toggleX`, `reset`, `setX`) instead of mutating state from components.
+- Co-locate a tiny spec near the store when adding new behavior. `src/lib/stores/uiSettings.spec.ts` shows the baseline expectations.
+
+```ts
+// src/lib/stores/uiSettings.svelte.ts
+export class UiSettingsStore {
+showGender = $state(true);
+highlightUnhappy = $state(false);
+
+setShowGender(value: boolean) {
+this.showGender = value;
+}
+
+toggleHighlightUnhappy() {
+this.highlightUnhappy = !this.highlightUnhappy;
+}
+
+reset() {
+this.showGender = true;
+this.highlightUnhappy = false;
+}
+}
+
+export const uiSettings = new UiSettingsStore();
+```
+
+```svelte
+<!-- Consuming components stay reactive via $derived -->
+<script lang="ts">
+import { uiSettings } from '$lib/stores/uiSettings.svelte';
+const showGender = $derived(uiSettings.showGender);
+
+function handleToggle(event: Event) {
+const input = event.currentTarget as HTMLInputElement | null;
+if (!input) return;
+uiSettings.setShowGender(input.checked);
+}
+</script>
+
+<input type="checkbox" checked={showGender} on:change={handleToggle} />
+```
+
 ### Comments
 - JSDoc for public APIs
 - Inline comments for non-obvious logic

--- a/src/lib/components/student/StudentCard.svelte
+++ b/src/lib/components/student/StudentCard.svelte
@@ -41,6 +41,8 @@
 	const prefMap = preferencesById ?? {};
 
 	const groups = $derived(commandStore.groups);
+	const showGenderSetting = $derived(uiSettings.showGender);
+	const highlightUnhappySetting = $derived(uiSettings.highlightUnhappy);
 
 	// Derive display values
         const displayName = $derived(getDisplayName(student));
@@ -101,7 +103,7 @@
 
 	// Gender badge configuration
 	const genderBadge = $derived.by(() => {
-		if (!uiSettings.showGender || !student.gender) return null;
+		if (!showGenderSetting || !student.gender) return null;
 
 		const g = student.gender.toUpperCase();
 		if (g === 'F') return { label: 'F', color: '#a855f7' }; // Purple
@@ -152,7 +154,7 @@
 	// Determine if student needs assistance (happiness < 2)
 	const needsAssistance = $derived(hasData && happiness < 2);
 	// Determine if we should show needs-assistance styling
-	const shouldHighlightUnhappy = $derived(uiSettings.highlightUnhappy && needsAssistance);
+	const shouldHighlightUnhappy = $derived(highlightUnhappySetting && needsAssistance);
 </script>
 
 <div

--- a/src/lib/stores/uiSettings.spec.ts
+++ b/src/lib/stores/uiSettings.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { UiSettingsStore } from './uiSettings.svelte';
+
+describe('UiSettingsStore', () => {
+        it('toggles individual flags', () => {
+                const store = new UiSettingsStore();
+
+                expect(store.showGender).toBe(true);
+                expect(store.highlightUnhappy).toBe(false);
+
+                store.toggleShowGender();
+                store.toggleHighlightUnhappy();
+
+                expect(store.showGender).toBe(false);
+                expect(store.highlightUnhappy).toBe(true);
+        });
+
+        it('resets back to default values', () => {
+                const store = new UiSettingsStore();
+
+                store.setShowGender(false);
+                store.setHighlightUnhappy(true);
+
+                store.reset();
+
+                expect(store.showGender).toBe(true);
+                expect(store.highlightUnhappy).toBe(false);
+        });
+});

--- a/src/lib/stores/uiSettings.svelte.ts
+++ b/src/lib/stores/uiSettings.svelte.ts
@@ -1,30 +1,45 @@
 /**
  * UI Settings Store: Client-side display preferences
- * 
+ *
  * This store manages ephemeral UI state that doesn't need undo/redo
  * or persistence. Examples: visual toggles, view modes, display filters.
- * 
+ *
  * Architecture:
  * - Stores are for mutable, frequently-changing UI state
  * - Context (appData) is for immutable reference data
  * - commandStore is for business logic with undo/redo
  */
 
-let showGender = $state(true);
-let highlightUnhappy = $state(false);
+/**
+ * Store implementation that keeps each preference in a $state rune.
+ *
+ * Using a class keeps related state + methods co-located and makes
+ * instantiating fresh stores inside tests straightforward.
+ */
+export class UiSettingsStore {
+        showGender = $state(true);
+        highlightUnhappy = $state(false);
 
-export const uiSettings = {
-	get showGender() {
-		return showGender;
-	},
-	set showGender(val: boolean) {
-		showGender = val;
-	},
+        setShowGender(value: boolean) {
+                this.showGender = value;
+        }
 
-	get highlightUnhappy() {
-		return highlightUnhappy;
-	},
-	set highlightUnhappy(val: boolean) {
-		highlightUnhappy = val;
-	}
-};
+        setHighlightUnhappy(value: boolean) {
+                this.highlightUnhappy = value;
+        }
+
+        toggleShowGender() {
+                this.showGender = !this.showGender;
+        }
+
+        toggleHighlightUnhappy() {
+                this.highlightUnhappy = !this.highlightUnhappy;
+        }
+
+        reset() {
+                this.showGender = true;
+                this.highlightUnhappy = false;
+        }
+}
+
+export const uiSettings = new UiSettingsStore();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
 	import type { StudentPreference } from '$lib/types/preferences';
 	import { commandStore } from '$lib/stores/commands.svelte';
 	import { createUiControlsStore } from '$lib/stores/uiControlsStore';
+	import { uiSettings } from '$lib/stores/uiSettings.svelte';
 	import {
 		SHEET_DATA_GUIDANCE,
 		SheetDataError,
@@ -44,12 +45,12 @@
 	// controls
 	let numberOfGroups = $state(4);
 	let targetGroupSize = $state(10);
-	let showGender = $state(true);
 
 	// groups
 	// Read groups from store (reactive)
 	// This creates a reactive reference - when store's groups change, UI updates
 	let groups = $derived(commandStore.groups);
+	const showGenderSetting = $derived(uiSettings.showGender);
 	const unassigned = $derived.by(() => {
 		const assignedIds = new Set(groups.flatMap((g) => g.memberIds));
 		return studentOrder.filter((id) => !assignedIds.has(id));
@@ -127,6 +128,13 @@
 		selectedStudentId = null;
 		parseError = null;
 		unknownFriendIds = new Set();
+		uiSettings.reset();
+	}
+
+	function handleShowGenderChange(event: Event) {
+		const input = event.currentTarget as HTMLInputElement | null;
+		if (!input) return;
+		uiSettings.setShowGender(input.checked);
 	}
 
 	function clearAssignments() {
@@ -417,7 +425,11 @@
 			</div>
 
 			<label class="flex items-center gap-2 text-sm">
-				<input type="checkbox" bind:checked={showGender} />
+				<input
+					type="checkbox"
+					checked={showGenderSetting}
+					on:change={handleShowGenderChange}
+				/>
 				Show gender badges
 			</label>
 


### PR DESCRIPTION
## Summary
- convert the uiSettings store into a class-based $state implementation with toggle/reset helpers and document the pattern for future stores
- update StudentCard and the main page to consume the reactive properties, including wiring the Show gender checkbox directly to the store
- add a lightweight vitest spec that exercises the new store API

## Testing
- pnpm test:unit -- --run *(fails: browser tests need Playwright binaries in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b991f73ec8328bb50e5514ffdbde2)