### PR TITLE
Add list programs use case and update programs page

### DIFF
--- a/src/lib/application/useCases/index.ts
+++ b/src/lib/application/useCases/index.ts
@@ -3,3 +3,4 @@ export * from './createProgram';
 export * from './generateScenario';
 export * from './computeScenarioAnalytics';
 export * from './getStudentView';
+export * from './listPrograms';

--- a/src/lib/application/useCases/listPrograms.ts
+++ b/src/lib/application/useCases/listPrograms.ts
@@ -1,0 +1,58 @@
+import type { PoolRepository, ProgramRepository } from '$lib/application/ports';
+import type { Pool, Program } from '$lib/domain';
+import type { Result } from '$lib/types/result';
+import { err, ok } from '$lib/types/result';
+
+export interface ProgramWithPrimaryPool {
+        program: Program;
+        primaryPool: Pool | null;
+}
+
+export type ListProgramsError =
+        | { type: 'PROGRAM_LIST_FAILED'; message: string }
+        | { type: 'POOL_LOOKUP_FAILED'; message: string };
+
+function getPrimaryPoolId(program: Program): string | null {
+        return program.primaryPoolId ?? program.poolIds[0] ?? null;
+}
+
+export async function listPrograms(
+        deps: { programRepo: ProgramRepository; poolRepo: PoolRepository }
+): Promise<Result<ProgramWithPrimaryPool[], ListProgramsError>> {
+        let programs: Program[];
+        try {
+                programs = await deps.programRepo.listAll();
+        } catch (e) {
+                const message = e instanceof Error ? e.message : 'Unknown program listing error';
+                return err({ type: 'PROGRAM_LIST_FAILED', message });
+        }
+
+        const primaryPoolIds = new Set<string>();
+        for (const program of programs) {
+                const primaryPoolId = getPrimaryPoolId(program);
+                if (primaryPoolId) {
+                        primaryPoolIds.add(primaryPoolId);
+                }
+        }
+
+        let poolsById: Record<string, Pool | null> = {};
+        try {
+                const poolEntries = await Promise.all(
+                        Array.from(primaryPoolIds).map(async (id) => {
+                                const pool = await deps.poolRepo.getById(id);
+                                return [id, pool as Pool | null] as const;
+                        })
+                );
+                poolsById = Object.fromEntries(poolEntries);
+        } catch (e) {
+                const message = e instanceof Error ? e.message : 'Unknown pool lookup error';
+                return err({ type: 'POOL_LOOKUP_FAILED', message });
+        }
+
+        return ok(
+                programs.map((program) => ({
+                        program,
+                        primaryPool: poolsById[getPrimaryPoolId(program) ?? ''] ?? null
+                }))
+        );
+}

--- a/src/lib/services/appEnvUseCases.ts
+++ b/src/lib/services/appEnvUseCases.ts
@@ -24,10 +24,15 @@ import type { Pool } from '$lib/domain';
 import type { ImportPoolFromCsvInput, ImportPoolFromCsvError } from '$lib/application/useCases/importPoolFromCsv';
 import { importPoolFromCsv } from '$lib/application/useCases/importPoolFromCsv';
 import type {
-	CreatePoolFromRosterDataInput,
-	CreatePoolFromRosterDataError
+        CreatePoolFromRosterDataInput,
+        CreatePoolFromRosterDataError
 } from '$lib/application/useCases/createPoolFromRosterData';
 import { createPoolFromRosterData } from '$lib/application/useCases/createPoolFromRosterData';
+import type {
+        ListProgramsError,
+        ProgramWithPrimaryPool
+} from '$lib/application/useCases/listPrograms';
+import { listPrograms as listProgramsUseCase } from '$lib/application/useCases/listPrograms';
 import type { RosterData } from '$lib/services/rosterImport';
 import type { Result } from '$lib/types/result';
 
@@ -108,16 +113,27 @@ export async function getStudentViewForScenario(
 }
 
 export async function createPoolFromRoster(
-	env: InMemoryEnvironment,
-	input: Omit<CreatePoolFromRosterDataInput, 'rosterData'> & { rosterData: RosterData }
+        env: InMemoryEnvironment,
+        input: Omit<CreatePoolFromRosterDataInput, 'rosterData'> & { rosterData: RosterData }
 ): Promise<Result<Pool, CreatePoolFromRosterDataError>> {
-	return createPoolFromRosterData(
+        return createPoolFromRosterData(
 		{
 			poolRepo: env.poolRepo,
 			studentRepo: env.studentRepo,
 			staffRepo: env.staffRepo,
 			idGenerator: env.idGenerator
-		},
-		input
-	);
+                },
+                input
+        );
+}
+
+export async function listPrograms(
+        env: InMemoryEnvironment
+): Promise<Result<ProgramWithPrimaryPool[], ListProgramsError>> {
+        return listProgramsUseCase(
+                {
+                        programRepo: env.programRepo,
+                        poolRepo: env.poolRepo
+                }
+        );
 }

--- a/src/routes/programs/+page.svelte
+++ b/src/routes/programs/+page.svelte
@@ -1,51 +1,46 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { getAppEnvContext } from '$lib/contexts/appEnv';
-	import type { Program, Pool } from '$lib/domain';
+        import { onMount } from 'svelte';
+        import { getAppEnvContext } from '$lib/contexts/appEnv';
+        import type { Program } from '$lib/domain';
+        import type { ProgramWithPrimaryPool } from '$lib/application/useCases/listPrograms';
+        import { listPrograms } from '$lib/services/appEnvUseCases';
+        import { isOk } from '$lib/types/result';
 
-	let programs: Program[] = [];
-	let poolsById: Record<string, Pool> = {};
-	let isLoading = true;
-	let loadError: string | null = null;
+        let programsWithPools: ProgramWithPrimaryPool[] = [];
+        let isLoading = true;
+        let loadError: string | null = null;
 
-	onMount(async () => {
-		try {
-			const env = getAppEnvContext();
-			isLoading = true;
-			loadError = null;
+        onMount(async () => {
+                try {
+                        const env = getAppEnvContext();
+                        isLoading = true;
+                        loadError = null;
 
-			const allPrograms = await env.programRepo.listAll();
-			programs = allPrograms;
+                        const result = await listPrograms(env);
+                        if (isOk(result)) {
+                                programsWithPools = result.value;
+                        } else {
+                                loadError = result.error.message;
+                        }
+                } catch (e) {
+                        loadError = e instanceof Error ? e.message : 'Unknown error loading programs';
+                } finally {
+                        isLoading = false;
+                }
+        });
 
-			// Load all referenced primary pools so we can show names.
-			const poolIds = new Set<string>();
-			for (const p of allPrograms) {
-				const primaryPoolId = p.primaryPoolId ?? p.poolIds[0];
-				if (primaryPoolId) {
-					poolIds.add(primaryPoolId);
-				}
-			}
+        function getPrimaryPoolName(entry: ProgramWithPrimaryPool): string {
+                const primaryPoolId = entry.program.primaryPoolId ?? entry.program.poolIds[0];
+                if (entry.primaryPool) return entry.primaryPool.name;
+                return primaryPoolId ?? '—';
+        }
 
-			const loadedPools: Pool[] = [];
-			for (const id of poolIds) {
-				const pool = await env.poolRepo.getById(id);
-				if (pool) loadedPools.push(pool);
-			}
-
-			poolsById = Object.fromEntries(loadedPools.map((p) => [p.id, p]));
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Unknown error loading programs';
-		} finally {
-			isLoading = false;
-		}
-	});
-
-	function getPrimaryPoolName(program: Program): string {
-		const primaryPoolId = program.primaryPoolId ?? program.poolIds[0];
-		if (!primaryPoolId) return '—';
-		const pool = poolsById[primaryPoolId];
-		return pool ? pool.name : primaryPoolId;
-	}
+        function formatTimeSpan(program: Program): string {
+                if ('termLabel' in program.timeSpan) {
+                        return program.timeSpan.termLabel;
+                }
+                return `${program.timeSpan.start.toLocaleDateString()}–${program.timeSpan.end.toLocaleDateString()}`;
+        }
 </script>
 
 <div class="mx-auto max-w-5xl space-y-6 p-4">
@@ -63,38 +58,32 @@
 		<p class="text-gray-600">Loading programs…</p>
 	{:else if loadError}
 		<p class="text-sm text-red-600">{loadError}</p>
-	{:else if programs.length === 0}
-		<p class="text-sm text-gray-600">
-			No programs yet. Click
-			<a href="/programs/new" class="text-blue-600 underline">Import Pool &amp; Create Program</a>
-			to get started.
-		</p>
-	{:else}
-		<table class="min-w-full divide-y border text-sm">
-			<thead class="bg-gray-50">
-				<tr>
-					<th class="px-3 py-2 text-left font-medium text-gray-700">Name</th>
-					<th class="px-3 py-2 text-left font-medium text-gray-700">Type</th>
-					<th class="px-3 py-2 text-left font-medium text-gray-700">Term</th>
-					<th class="px-3 py-2 text-left font-medium text-gray-700">Primary Pool</th>
-				</tr>
-			</thead>
-			<tbody class="divide-y">
-				{#each programs as program}
-					<tr>
-						<td class="px-3 py-2">{program.name}</td>
-						<td class="px-3 py-2">{program.type}</td>
-						<td class="px-3 py-2">
-							{#if 'termLabel' in program.timeSpan}
-								{program.timeSpan.termLabel}
-							{:else}
-								{program.timeSpan.start.toLocaleDateString()}–{program.timeSpan.end.toLocaleDateString()}
-							{/if}
-						</td>
-						<td class="px-3 py-2">{getPrimaryPoolName(program)}</td>
-					</tr>
-				{/each}
-			</tbody>
-		</table>
-	{/if}
+        {:else if programsWithPools.length === 0}
+                <p class="text-sm text-gray-600">
+                        No programs yet. Click
+                        <a href="/programs/new" class="text-blue-600 underline">Import Pool &amp; Create Program</a>
+                        to get started.
+                </p>
+        {:else}
+                <table class="min-w-full divide-y border text-sm">
+                        <thead class="bg-gray-50">
+                                <tr>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-700">Name</th>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-700">Type</th>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-700">Term</th>
+                                        <th class="px-3 py-2 text-left font-medium text-gray-700">Primary Pool</th>
+                                </tr>
+                        </thead>
+                        <tbody class="divide-y">
+                                {#each programsWithPools as entry}
+                                        <tr>
+                                                <td class="px-3 py-2">{entry.program.name}</td>
+                                                <td class="px-3 py-2">{entry.program.type}</td>
+                                                <td class="px-3 py-2">{formatTimeSpan(entry.program)}</td>
+                                                <td class="px-3 py-2">{getPrimaryPoolName(entry)}</td>
+                                        </tr>
+                                {/each}
+                        </tbody>
+                </table>
+        {/if}
 </div>


### PR DESCRIPTION
## Summary
- add a listPrograms use case to fetch programs alongside their primary pool metadata through ports
- expose a matching app environment façade helper for invoking the use case
- update the programs page to load programs via the façade and handle Result-based loading and errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69212d0aed548328ab3f891e98316a3c)