### PR TITLE
Import global styles in layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import '../app.css';
+
   import { browser } from '$app/environment';
   import { page } from '$app/stores';
   import { setAppEnvContext } from '$lib/contexts/appEnv';


### PR DESCRIPTION
## Summary
- import the global `app.css` stylesheet in the root layout so Tailwind utility classes load sitewide

## Testing
- npm run check *(fails: pre-existing Svelte check errors about CreateProgramError/GetProgramError types and deprecated event directives)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbfd40c808328abf7cea4b3131a6b)