### PR TITLE
Fix check errors and update event handlers

### DIFF
--- a/src/lib/components/group/GroupColumn.svelte
+++ b/src/lib/components/group/GroupColumn.svelte
@@ -66,7 +66,7 @@
                         type="text"
                         class="group-name-input"
                         value={group.name}
-                        on:input={(e) => onUpdateGroup?.(group.id, { name: e.currentTarget.value })}
+                        oninput={(e) => onUpdateGroup?.(group.id, { name: e.currentTarget.value })}
                         placeholder="Group name"
                 />
 		<div class="capacity-controls">
@@ -88,7 +88,7 @@
                                 value={group.capacity ?? ''}
                                 min="1"
                                 placeholder="∞"
-                                on:input={(e) => {
+                                oninput={(e) => {
                                         const val = e.currentTarget.value;
                                         const num = parseInt(val, 10);
                                         const newCapacity = val === '' || isNaN(num) || num <= 0 ? null : num;

--- a/src/lib/components/group/VerticalGroupLayout.svelte
+++ b/src/lib/components/group/VerticalGroupLayout.svelte
@@ -84,7 +84,7 @@
 			<div class="group-row-header">
                                 <button
                                         class="collapse-button"
-                                        on:click={() => onToggleCollapse(group.id)}
+                                        onclick={() => onToggleCollapse(group.id)}
                                         aria-label={isCollapsed(group.id) ? `Expand ${group.name}` : `Collapse ${group.name}`}
                                         title={isCollapsed(group.id) ? 'Expand' : 'Collapse'}
                                 >
@@ -95,7 +95,7 @@
                                         type="text"
                                         class="group-row-name-input"
                                         value={group.name}
-                                        on:input={(e) => onUpdateGroup?.(group.id, { name: e.currentTarget.value })}
+                                        oninput={(e) => onUpdateGroup?.(group.id, { name: e.currentTarget.value })}
                                         placeholder="Group name"
                                 />
 
@@ -118,7 +118,7 @@
                                                 value={group.capacity ?? ''}
                                                 min="1"
                                                 placeholder="∞"
-                                                on:input={(e) => {
+                                                oninput={(e) => {
                                                         const val = e.currentTarget.value;
                                                         const num = parseInt(val, 10);
                                                         const newCapacity = val === '' || isNaN(num) || num <= 0 ? null : num;

--- a/src/lib/components/student/StudentCard.svelte
+++ b/src/lib/components/student/StudentCard.svelte
@@ -171,8 +171,8 @@
                         onDragEnd
                 }
         }}
-        on:click={() => onClick?.()}
-        on:keydown={(event) => {
+        onclick={() => onClick?.()}
+        onkeydown={(event) => {
                 if (event.key === 'Enter' || event.key === ' ') {
                         event.preventDefault();
                         onClick?.();


### PR DESCRIPTION
## Summary
- add explicit error-type helpers in use case specs to satisfy TypeScript narrowing
- update student and group components to use Svelte 5 event attributes instead of deprecated directives
- ensure tests and typings align with Svelte 5 migration expectations

## Testing
- npm run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cc1c83d548328a070515f74dea6f2)